### PR TITLE
add nprn receive listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,22 @@ WebMidi.enable(function (err) {
       console.log("Received 'controlchange' message.", e);
     }
   );
+  
+  // Listen to NRPN message on all channels
+  input.addListener('nrpn', "all",
+    function (e) {
+      if(e.controller.type === 'entry') {
+        console.log("Received 'nrpn' 'entry' message.", e);
+      }
+      if(e.controller.type === 'decrement') {
+        console.log("Received 'nrpn' 'decrement' message.", e);
+      }
+      if(e.controller.type === 'increment') {
+        console.log("Received 'nrpn' 'increment' message.", e);
+      }
+      console.log("message value: " + e.controller.value + ".", e);
+    }
+  );
 
   // Check for the presence of an event listener (n such cases, you cannot use anonymous functions).
   function test(e) { console.log(e); }
@@ -338,39 +354,6 @@ WebMidi.enable(function (err) {
 ```
 **Important**: depending on the browser, version and platform, it may also be necessary to serve the 
 page over https if you want to enable sysex support.
-
-## Explicit NRPN Listener
-
-Listening for NPRN messages directly is not standardized so is disabled by default. If you would
-like to listen for `nrpn` events, you will need to pass `true` as the third parameter to `WebMidi.enable()`:
-
-```javascript
-WebMidi.enable(function (err) {
-  if (err) {
-    console.log("WebMidi could not be enabled.", err);
-  }
-
-  var input = WebMidi.inputs[0];
-  function nrpnListener(e) {
-    console.log("NRPN #: " + e.controller.number);
-    console.log("NRPN type: " + e.controller.type);
-    console.log("NRPN Value: " + e.value);
-  }
-  input.addListener('nrpn', 8, test);
-  input.addListener('nrpn', 9, test);
-  input.addListener('nrpn', 10, test);
-  input.addListener('nrpn', 11, test);
-  console.log("nrpnEnabled: ", WebMidi.nrpnEnabled);
-
-}, false, true);
-```
-The nature of NPRN messages is that they utilize groups of CC messages together to provide two other
-types of controls: increment/decrement (1 or -1) values and 14-bit (16,384 possible values).
-As shown above in the code example, `nrpn` event objects will have a `controller.type` property.
-This will have the value of either `parameter` or `incremental`.
-
-The CC messages used are 6, 38, 96, 97, 98, and 99. These should not be expected to work as
-regular CC's if you use CC 99. It is best to just not use these CC's if you are using this feature.
 
 ## Migration Notes
 

--- a/README.md
+++ b/README.md
@@ -339,6 +339,39 @@ WebMidi.enable(function (err) {
 **Important**: depending on the browser, version and platform, it may also be necessary to serve the 
 page over https if you want to enable sysex support.
 
+## Explicit NRPN Listener
+
+Listening for NPRN messages directly is not standardized so is disabled by default. If you would
+like to listen for `nrpn` events, you will need to pass `true` as the third parameter to `WebMidi.enable()`:
+
+```javascript
+WebMidi.enable(function (err) {
+  if (err) {
+    console.log("WebMidi could not be enabled.", err);
+  }
+
+  var input = WebMidi.inputs[0];
+  function nrpnListener(e) {
+    console.log("NRPN #: " + e.controller.number);
+    console.log("NRPN type: " + e.controller.type);
+    console.log("NRPN Value: " + e.value);
+  }
+  input.addListener('nrpn', 8, test);
+  input.addListener('nrpn', 9, test);
+  input.addListener('nrpn', 10, test);
+  input.addListener('nrpn', 11, test);
+  console.log("nrpnEnabled: ", WebMidi.nrpnEnabled);
+
+}, false, true);
+```
+The nature of NPRN messages is that they utilize groups of CC messages together to provide two other
+types of controls: increment/decrement (1 or -1) values and 14-bit (16,384 possible values).
+As shown above in the code example, `nrpn` event objects will have a `controller.type` property.
+This will have the value of either `parameter` or `incremental`.
+
+The CC messages used are 6, 38, 96, 97, 98, and 99. These should not be expected to work as
+regular CC's if you use CC 99. It is best to just not use these CC's if you are using this feature.
+
 ## Migration Notes
 
 If you are upgrading from version 1.x to 2.x, you should know that v2.x is not backwards compatible.

--- a/test/browser/input.js
+++ b/test/browser/input.js
@@ -75,6 +75,12 @@ describe('Input', function() {
       expect(WebMidi.inputs[0].hasListener('controlchange', [1, 2, 3], a)).to.equal(true);
       expect(WebMidi.inputs[0].hasListener('controlchange', "all", a)).to.equal(false);
 
+      WebMidi.inputs[0].addListener('nrpn', [1, 2, 3], a);
+      expect(WebMidi.inputs[0].hasListener('nrpn', 3, a)).to.equal(true);
+      expect(WebMidi.inputs[0].hasListener('nrpn', [1, 3], a)).to.equal(true);
+      expect(WebMidi.inputs[0].hasListener('nrpn', [1, 2, 3], a)).to.equal(true);
+      expect(WebMidi.inputs[0].hasListener('nrpn', "all", a)).to.equal(false);
+
       WebMidi.inputs[0].addListener('channelmode', "all", a);
       expect(WebMidi.inputs[0].hasListener('channelmode', 3, a)).to.equal(true);
       expect(WebMidi.inputs[0].hasListener('channelmode', "all", a)).to.equal(true);
@@ -118,6 +124,12 @@ describe('Input', function() {
       expect(WebMidi.inputs[0].hasListener('controlchange', [1, 3], a)).to.equal(true);
       expect(WebMidi.inputs[0].hasListener('controlchange', [1, 2, 3], a)).to.equal(true);
       expect(WebMidi.inputs[0].hasListener('controlchange', "all", a)).to.equal(false);
+
+      WebMidi.inputs[0].addListener('nrpn', [1, 2, 3], a);
+      expect(WebMidi.inputs[0].hasListener('nrpn', 3, a)).to.equal(true);
+      expect(WebMidi.inputs[0].hasListener('nrpn', [1, 3], a)).to.equal(true);
+      expect(WebMidi.inputs[0].hasListener('nrpn', [1, 2, 3], a)).to.equal(true);
+      expect(WebMidi.inputs[0].hasListener('nrpn', "all", a)).to.equal(false);
 
       WebMidi.inputs[0].addListener('channelmode', "all", a);
       expect(WebMidi.inputs[0].hasListener('channelmode', 3, a)).to.equal(true);

--- a/test/headless/input.test.js
+++ b/test/headless/input.test.js
@@ -102,6 +102,12 @@ describe("Input", function() {
       expect(WebMidi.inputs[0].hasListener("controlchange", [1, 2, 3], a)).to.equal(true);
       expect(WebMidi.inputs[0].hasListener("controlchange", "all", a)).to.equal(false);
 
+      WebMidi.inputs[0].addListener('nrpn', [1, 2, 3], a);
+      expect(WebMidi.inputs[0].hasListener('nrpn', 3, a)).to.equal(true);
+      expect(WebMidi.inputs[0].hasListener('nrpn', [1, 3], a)).to.equal(true);
+      expect(WebMidi.inputs[0].hasListener('nrpn', [1, 2, 3], a)).to.equal(true);
+      expect(WebMidi.inputs[0].hasListener('nrpn', "all", a)).to.equal(false);
+
       WebMidi.inputs[0].addListener("channelmode", "all", a);
       expect(WebMidi.inputs[0].hasListener("channelmode", 3, a)).to.equal(true);
       expect(WebMidi.inputs[0].hasListener("channelmode", "all", a)).to.equal(true);
@@ -145,6 +151,12 @@ describe("Input", function() {
       expect(WebMidi.inputs[0].hasListener("controlchange", [1, 3], a)).to.equal(true);
       expect(WebMidi.inputs[0].hasListener("controlchange", [1, 2, 3], a)).to.equal(true);
       expect(WebMidi.inputs[0].hasListener("controlchange", "all", a)).to.equal(false);
+
+      WebMidi.inputs[0].addListener('nrpn', [1, 2, 3], a);
+      expect(WebMidi.inputs[0].hasListener('nrpn', 3, a)).to.equal(true);
+      expect(WebMidi.inputs[0].hasListener('nrpn', [1, 3], a)).to.equal(true);
+      expect(WebMidi.inputs[0].hasListener('nrpn', [1, 2, 3], a)).to.equal(true);
+      expect(WebMidi.inputs[0].hasListener('nrpn', "all", a)).to.equal(false);
 
       WebMidi.inputs[0].addListener("channelmode", "all", a);
       expect(WebMidi.inputs[0].hasListener("channelmode", 3, a)).to.equal(true);


### PR DESCRIPTION
Hey Webmidi crew! Thanks for all your work on this library so far.
I have seen a few issues where people mentioned receiving NRPN messages and I also wanted this feature to be in the WebMidi library for my own use. 

If it is something that you would like to include, please let me know if there are any changes that can help it be consistent with the current code. I am able to test it with my Akai MPD218, which does the incremental NRPNs and its working on knobs across multiple channels.