### PR TITLE
Option to swap out requestMIDIAccess function when enabling WebMIDI

### DIFF
--- a/src/WebMidi.js
+++ b/src/WebMidi.js
@@ -218,6 +218,11 @@ class WebMidi extends EventEmitter {
    * @param [options.software=false] {boolean} Whether to request access to software synthesizers on
    * the host system. This is part of the spec but has not yet been implemented by most browsers as
    * of April 2020.
+   * 
+   * @param [options.requestMIDIAccessFunction] {function} A custom function to use to return 
+   * the MIDIAccess object. This is useful if you want to use a polyfill for the Web MIDI API 
+   * or if you want to use a custom implementation of the Web MIDI API - probably for testing
+   * purposes.
    *
    * @async
    *
@@ -360,9 +365,15 @@ class WebMidi extends EventEmitter {
 
     // Request MIDI access (this iw where the prompt will appear)
     try {
-      this.interface = await navigator.requestMIDIAccess(
-        {sysex: options.sysex, software: options.software}
-      );
+      if (typeof options.requestMIDIAccessFunction === "function") {
+        this.interface = await options.requestMIDIAccessFunction(
+          {sysex: options.sysex, software: options.software}
+        );
+      } else {
+        this.interface = await navigator.requestMIDIAccess(
+          {sysex: options.sysex, software: options.software}
+        );
+      }
     } catch(err) {
       errorEvent.error = err;
       this.emit("error", errorEvent);

--- a/typescript/webmidi.d.ts
+++ b/typescript/webmidi.d.ts
@@ -5570,6 +5570,7 @@ declare class WebMidi extends EventEmitter {
     sysex?: boolean;
     validation?: boolean;
     software?: boolean;
+    requestMIDIAccessFunction?: Function;
   }): Promise<WebMidi>;
 
   /**


### PR DESCRIPTION
Adds a requestMIDIAccessFunction property to the options object argument of `WebMIDI.enable()`. If this property exists (and is a function), it will be called instead of `navigator.requestMIDIAccess`. This seems to work in my tests, however I can’t get WebMIDI to build because there seems to be a missing `typescript-declarations/generate.js` file… so I’m not sure if the unit tests are working correctly for me.