### PR TITLE
website: Add trailing slash to `/api` to prevent 404

### DIFF
--- a/website/api/index.md
+++ b/website/api/index.md
@@ -11,28 +11,28 @@ slug: /
 These classes are the ones developers are most likely to be dealing with while working on their MIDI 
 projects. Note that all these classes are pre-instantiated within WebMidi.js.
 
-* [**WebMidi**](api/classes/WebMidi)
-* [**Input**](api/classes/Input)
-* [**InputChannel**](api/classes/InputChannel)
-* [**Output**](api/classes/Output)
-* [**OutputChannel**](api/classes/OutputChannel)
-* [**Message**](api/classes/Message)
+* [**WebMidi**](classes/WebMidi)
+* [**Input**](classes/Input)
+* [**InputChannel**](classes/InputChannel)
+* [**Output**](classes/Output)
+* [**OutputChannel**](classes/OutputChannel)
+* [**Message**](classes/Message)
 
-The exception are the [`Note`](api/classes/Note) class which you can instantiate when you need to store 
-a musical note and the [`Forwarder`](api/classes/Forwarder) class used to forward messages from an input
+The exception are the [`Note`](classes/Note) class which you can instantiate when you need to store 
+a musical note and the [`Forwarder`](classes/Forwarder) class used to forward messages from an input
 to an output:
 
-* [**Note**](api/classes/Note)
-* [**Forwarder**](api/classes/Forwarder)
+* [**Note**](classes/Note)
+* [**Forwarder**](classes/Forwarder)
 
 ## Support Classes
 
 These classes are mostly for internal use, but you might find them useful in some contexts. The 
-[`Enumerations`](api/classes/Enumerations) class contains static enums of MIDI messages, registered 
-parameters, etc. The [`Utilities`](api/classes/Utilities) class contains various static methods. 
+[`Enumerations`](classes/Enumerations) class contains static enums of MIDI messages, registered 
+parameters, etc. The [`Utilities`](classes/Utilities) class contains various static methods. 
 
-* [**Enumerations**](api/classes/Enumerations)
-* [**Utilities**](api/classes/Utilities)
+* [**Enumerations**](classes/Enumerations)
+* [**Utilities**](classes/Utilities)
 
 ## DjipEvents Classes
 
@@ -40,5 +40,5 @@ The `EventEmitter` and `Listener` classes from the [DjipEvents](https://github.c
 module are extended by various WebMidi.js classes. So, in the interest of completeness, we include
 their full documentation here and cross-reference it with the core classes
 
-* [**EventEmitter**](api/classes/EventEmitter)
-* [**Listener**](api/classes/Listener)
+* [**EventEmitter**](classes/EventEmitter)
+* [**Listener**](classes/Listener)

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -47,7 +47,7 @@ module.exports = {
           items: [
             {
               label: "3.x",
-              to: "api"
+              to: "api/"
             },
             {
               label: "2.5.3",


### PR DESCRIPTION
When navigating on the navbar to the 3.x API, you are redirected to `/api` and every links there are something like `api/classes/...`.

But when you're navigating using the sidebar in API, you're redirected to `/api/` which breaks all the links in the page because of the paths.

Here, my solution is to add the trailing slash to `/api` in the navbar and to remove all the `api/` in the links from the API index page.

Hope it helps !