### PR TITLE
fix(docs): fix broken link on quickstart page

### DIFF
--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -130,7 +130,7 @@ WebMidi.inputs[0].addListener("noteon", e => {
 ## Step 5 - Have fun!
 
 **That's it!** To go further, please take some time to check out the 
-[Getting Started](docs/getting-started) section. It covers important topics such as installation 
+[Getting Started](getting-started) section. It covers important topics such as installation 
 options, compatibility, security, etc.
 
 :::tip


### PR DESCRIPTION
There is a broken Link on the "Quickstart" Page (https://webmidijs.org/docs/) In the section "Step 5". The Link "Getting started".