### PR TITLE
Update name of synth.kitchen creator

### DIFF
--- a/website/src/pages/showcase/index.md
+++ b/website/src/pages/showcase/index.md
@@ -173,7 +173,7 @@ page on GitHub and submit a pull request.
 ## Online Synthesizers
 
 * ### [synth.kitchen](https://synth.kitchen/)
-  Created by: **Spencer Rudnick**
+  Created by: **Rain Rudnick**
 
   In-browser modular synthesis with Web Audio and Web MIDI.
 


### PR DESCRIPTION
I just noticed that synth.kitchen is featured on the Showcase page for WEBMIDI.js. Thanks for that!

This is a PR to update the creator name to the one I'm using now.

Thanks again for this great library :)