### PR TITLE
Add Bipluk to Showcase (SysEx Librarian)

### DIFF
--- a/website/src/pages/showcase/index.md
+++ b/website/src/pages/showcase/index.md
@@ -201,6 +201,11 @@ page on GitHub and submit a pull request.
   WEBMIDI.js for MIDI control of the device. 
 
 ## SysEx Librarian
+* ### [Bipluk](https://bipluk.com)
+  Created by: **Max Comperatore**
+
+  Bipluk is a browser-native Web MIDI SysEx librarian and cloud vault for 80+ vintage synthesizers (Yamaha DX7, Roland Juno-106, Korg M1, Sequential Prophet, Casio CZ). Features 31,250 baud CPU pacing, real-time ASCII patch decoding, and cloud backup.
+
 * ### [Patchup](https://www.patchup.app)
   Created by: **Middledot Tech**
 


### PR DESCRIPTION
Hi @djipco!

Submitting the showcase entry for [Bipluk](https://bipluk.com) as requested in discussion #162.

Bipluk is a browser-native Web MIDI SysEx librarian and cloud vault for vintage hardware synthesizers (Yamaha DX7, Roland Juno-106, Korg M1, Sequential Prophet, Casio CZ) with hardware-safe 31,250 baud CPU pacing and real-time ASCII patch decoding.

Added under the SysEx Librarian section. Thank you!